### PR TITLE
fix repo downloader

### DIFF
--- a/repo-downloader/Dockerfile
+++ b/repo-downloader/Dockerfile
@@ -9,7 +9,8 @@ ARG GID
 
 USER root
 
-RUN addgroup --gid $GID $GROUP && adduser -D -H --gecos "" --ingroup "$GROUP" --uid "$UID" "$USER"
+RUN addgroup --gid $GID $GROUP || true \
+  && adduser -D -H --gecos "" --ingroup `getent group $GID | cut -d: -f1` --uid "$UID" "$USER"
 
 USER $USER
 


### PR DESCRIPTION
Исправил ошибку "gid '20' in use" при билде образа  downloader на маке. Если группа уже есть, не создаем ее. А пользователя добавляем в уже имеющуюся группу.

В Alpine команда adduser не умеет добавлять пользователя в группу по gid, только по названию. Пришлось извлекать название группы 